### PR TITLE
Remove statement cache

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -2,28 +2,18 @@
 
 | Version | Released |
 | --- | --- |
-|[1.4.0](#v140)| `TBD` |
+|[1.3.1](#v131)| `TBD` |
 |[1.3.0](#v130)| `13 April 2022` |
 | [1.2.0](#v120) | `06 October 2020` |
 
 ---
 
-### v1.4.0
-
-##### Breaking Changes
-* None.
-
-##### New Features
-* None.
-
-##### Enhancements
-* None.
-
-##### Fixes
-* None.
+### v1.3.1
 
 ##### Notes
-* None.
+
+* Revert 1.3.0 to 1.2.0
+* Remove statement caching in SqliteBlobReader
 
 ---
 

--- a/pom.xml
+++ b/pom.xml
@@ -78,10 +78,6 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.zaxxer</groupId>
-            <artifactId>HikariCP</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>com.zepben</groupId>
     <artifactId>blob-store</artifactId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.3.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/com/zepben/blobstore/sqlite/SqliteConnectionFactory.java
+++ b/src/main/java/com/zepben/blobstore/sqlite/SqliteConnectionFactory.java
@@ -8,15 +8,12 @@
 
 package com.zepben.blobstore.sqlite;
 
-import com.zaxxer.hikari.HikariConfig;
-import com.zaxxer.hikari.HikariDataSource;
 import com.zepben.annotations.EverythingIsNonnullByDefault;
 
 import java.nio.file.Path;
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
+import java.sql.*;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -30,7 +27,6 @@ public class SqliteConnectionFactory implements ConnectionFactory {
 
     private final Set<String> tags;
     private final Path file;
-    private final HikariDataSource dbSource;
 
     @SuppressWarnings("WeakerAccess")
     public SqliteConnectionFactory(Path file, Set<String> tags) {
@@ -41,7 +37,6 @@ public class SqliteConnectionFactory implements ConnectionFactory {
 
         this.tags = Set.copyOf(tags);
         this.file = file;
-        this.dbSource = buildDbSource("jdbc:sqlite:file:" + file + "?cache=shared");
     }
 
     private boolean supportedTableName(String tag) {
@@ -63,7 +58,7 @@ public class SqliteConnectionFactory implements ConnectionFactory {
     public Connection getConnection() throws SQLException {
         Connection connection = null;
         try {
-            connection = dbSource.getConnection();
+            connection = DriverManager.getConnection("jdbc:sqlite:file:" + file.toString() + "?cache=shared");
 
             checkVersion(connection);
             createTables(connection);
@@ -153,18 +148,4 @@ public class SqliteConnectionFactory implements ConnectionFactory {
         }
     }
 
-    private HikariDataSource buildDbSource(String url) {
-        HikariConfig config = new HikariConfig();
-        config.setJdbcUrl(url);
-        // these are arbitrary and not scientific
-        config.addDataSourceProperty("cachePrepStmts", "true");
-        config.addDataSourceProperty("prepStmtCacheSize", "250");
-        config.addDataSourceProperty("prepStmtCacheSqlLimit", "2048");
-
-        // TODO: we don't need more than 1 connection in the pool atm; will add more if needed; potentially in the
-        // thread that works with the DB (not load-profiles)
-        config.setMaximumPoolSize(1);
-
-        return new HikariDataSource(config);
-    }
 }


### PR DESCRIPTION
Do not cache statements in SqliteBlobReader so that if there are
multiple threads working on the same object, they don't clash racing
for the ResultSet object.

Signed-off-by: Alex Lourie <alex.lourie@zepben.com>